### PR TITLE
Add docker-here script

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -31,6 +31,7 @@ Command | Description | Credit
 | `docker-create-backup-container` | Creates a container with all the volumes from all the containers on the host. | [From http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/](From http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/)
 | `docker-delete-stopped-containers` | Cleans up stale stopped containers. |
 | `docker-enter` | Install/Run jpetazzo's `nsenter`. |
+| `docker-here` | Builds an ephemeral container, runs it with the parameters you pass `docker-here`, then deletes the ephemeral container |
 | `docker-last` | Print the id of the last container you ran. |
 | `docker-lint` | Lint a Dockerfile with [hadolint](https://github.com/hadolint/hadolint). |
 | `docker-ps-cleanup` | Cleans up `docker ps` output by deleting all exited containers. |

--- a/bin/docker-here
+++ b/bin/docker-here
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Build and run an ephemeral docker image without making me remember the
+# commands to do so. Based on a discussion on hangops slack.
+
+IMAGE_ID=$(docker build -q .)
+docker run --rm -it "$IMAGE_ID" "$@"
+retval=$?
+docker rmi $IMAGE_ID
+exit $retval


### PR DESCRIPTION
`docker-here` builds an ephemeral docker image, then runs it passing the `docker-here` command line arguments and finally deletes the ephemeral image when it's done.

Nice during testing since it doesn't leave cruft in your docker image list.