### PR TITLE
Add docker-shell command

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,8 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [docker-helpers](#docker-helpers)
-- [Docker helper scripts](#docker-helper-scripts)
+- [Script list](#script-list)
 - [Installing](#installing)
   - [Pre-Requisites](#pre-requisites)
   - [zgen](#zgen)
@@ -15,15 +14,13 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# docker-helpers
-
 This is a collection of docker helper scripts, packaged as a zsh plugin to make it easier to use with [antigen](https://github.com/zsh-users/antigen).
 
 Most of these were collected from blog posts, gists, slack - basically stuff I saw and thought was useful enough to stash away, and I've given credit where I know the source.
 
 If you wrote something I've collected and I didn't credit you, please create an issue or PR so I can correct it.
 
-# Docker helper scripts
+## Script list
 
 Command | Description | Credit
 ------- | ----------- | ------
@@ -48,21 +45,21 @@ Command | Description | Credit
 | `docker-superclean` | Clear out any stopped containers or stale images. |
 | `docker-update-all-images` | Update all images on the machine. |
 
-# Installing
+## Installing
 
-## Pre-Requisites
+### Pre-Requisites
 
 `jq` - Install with `brew install jq`
 
-## zgen
+### zgen
 
 Add `zgen load unixorn/docker-helpers.zshplugin` to your `.zshrc` wherever you're loading your other plugins.
 
-## Antigen
+### Antigen
 
 Add `antigen bundle unixorn/docker-helpers.zshplugin` to your `.zshrc` with your other plugins. You can test drive them without editing your .zshrc by running `antigen bundle unixorn/docker-helpers.zshplugin` in a running zsh session.
 
-## Oh-My-Zsh
+### Oh-My-Zsh
 
 1. cd to your `oh-my-zsh` plugins directory (~/.oh-my-zsh/custom/plugins)
 2. `git clone https://github.com/unixorn/docker-helpers.zshplugin docker-helpers`
@@ -73,7 +70,7 @@ plugins=( ... docker-helpers ...)
 ...
 ```
 
-# Other useful Docker stuff
+## Other useful Docker stuff
 
 * If you use [Sublime Text 2/3](http://sublimetext.com), check out [sublime-docker](https://github.com/dockerparis/sublime-docker). Lets you build inside Docker containers directly from [Sublime Text](http://sublimetext.com).
 * [dive](https://github.com/wagoodman/dive) - A tool for exploring a docker image, layer contents, and discovering ways to shrink your Docker image size.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,5 @@
+# Docker helper scripts
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -38,6 +38,7 @@ Command | Description | Credit
 | `docker-purge-unnamed-images` | Cleans up image cruft by deleting all the images that aren't named. |
 | `docker-remove-dangling-images` | Cleans up image cruft by deleting all dangling images. |
 | `docker-runinc` | Uses [fzf](https://github.com/junegunn/fzf) to select a running container and run a command inside it. |
+| `docker-shell` | Runs a shell inside a container with `pwd` mounted as `/pwd`. Defaults to bash inside debian:buster-slim, reads shell & image name from `STANDARD_DOCKER_COMMAND` and `STANDARD_DOCKER_IMAGE` or `$1` and `$2`. |
 | `docker-showipc` | Show the IP of a running docker container. |
 | `docker-stopc` | Stops and/or removes a docker container. |
 | `docker-superclean` | Clear out any stopped containers or stale images. |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,12 +30,14 @@ Command | Description | Credit
 | `boot2docker-timesync` | boot2docker drifts out of time sync every time my MacBook Pro sleeps. Run this to resync. |
 | `dive` | Wrapper script that calls wagoodman/dive to analyze a container image. |
 | `docker-container-volumes` | List the volumes attached to a container. | [http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/](http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/))
-| `docker-create-backup-container` | Creates a container with all the volumes from all the containers on the host. | [From http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/](From http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/)
+| `docker-create-backup-container` | Creates a container with all the volumes from all the containers on the host. | From [http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/](http://www.tech-d.net/2014/05/05/docker-quicktip-5-backing-up-volumes/)
 | `docker-delete-stopped-containers` | Cleans up stale stopped containers. |
 | `docker-enter` | Install/Run jpetazzo's `nsenter`. |
-| `docker-here` | Builds an ephemeral container, runs it with the parameters you pass `docker-here`, then deletes the ephemeral container |
+| `docker-here` | Builds an ephemeral container, runs it with the parameters you pass `docker-here`, then deletes the ephemeral container. |
+| `docker-ip` | Gets the pid of a running container. |
 | `docker-last` | Print the id of the last container you ran. |
 | `docker-lint` | Lint a Dockerfile with [hadolint](https://github.com/hadolint/hadolint). |
+| `docker-pid` | Print pid of a running container. |
 | `docker-ps-cleanup` | Cleans up `docker ps` output by deleting all exited containers. |
 | `docker-purge-unnamed-images` | Cleans up image cruft by deleting all the images that aren't named. |
 | `docker-remove-dangling-images` | Cleans up image cruft by deleting all dangling images. |

--- a/bin/docker-ip
+++ b/bin/docker-ip
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Get the IP of a docker container
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+
+exec docker inspect --format "{{ .NetworkSettings.IPAddress }}" "$1"

--- a/bin/docker-pid
+++ b/bin/docker-pid
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Get pid of a docker container
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+
+exec docker inspect --format "{{ .State.Pid }}" "$1"

--- a/bin/docker-shell
+++ b/bin/docker-shell
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Run a shell in a docker container
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+
+STANDARD_DOCKER_IMAGE=${STANDARD_DOCKER_IMAGE:-'debian:buster-slim'}
+STANDARD_DOCKER_SHELL=${STANDARD_DOCKER_SHELL:-'bash'}
+
+if [[ "$1" == "--help" ]]; then
+  echo "Usage:"
+  # shellcheck disable=SC2086
+  echo "$(basename $0) optional-image-name optional-command"
+  echo "default is to run $STANDARD_DOCKER_SHELL inside $STANDARD_DOCKER_IMAGE"
+  echo
+  echo "Mounts current directory in container as /pwd"
+  exit 0
+fi
+
+if [[ -n "$1" ]]; then
+  IMAGE="$1"
+else
+  IMAGE="$STANDARD_DOCKER_IMAGE"
+fi
+if [[ -n "$2" ]]; then
+  DOCKER_COMMAND="$2"
+else
+  DOCKER_COMMAND="$STANDARD_DOCKER_SHELL"
+fi
+
+exec docker run -v "$(pwd):/pwd" --rm -it "$IMAGE" "$DOCKER_COMMAND"


### PR DESCRIPTION
- Add `docker-shell` - For Reasons I frequently want to run a shell inside a docker container to see how a command will work on linux compared to my Mac.
- Add `docker-ip` - Print the IP address of a running container
- Add `docker-pid` - Print the pid of a running container