### PR TITLE
docker-shell now starts in working directory /pwd

### DIFF
--- a/bin/docker-shell
+++ b/bin/docker-shell
@@ -28,4 +28,4 @@ else
   DOCKER_COMMAND="$STANDARD_DOCKER_SHELL"
 fi
 
-exec docker run -v "$(pwd):/pwd" --rm -it "$IMAGE" "$DOCKER_COMMAND"
+exec docker run -v "$(pwd):/pwd" -w "/pwd" --rm -it "$IMAGE" "$DOCKER_COMMAND"


### PR DESCRIPTION
# Description

Updates `docker-shell` to include the `-w "/pwd"` flag so that, once the container opens, the user has the directory contents right in front of them without needing to add an additional `cd`.

# Type of changes

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is the only exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
